### PR TITLE
fix: XPath query in scrapy shell

### DIFF
--- a/_episodes/05-scraping-multiple-pages-with-scrapy.md
+++ b/_episodes/05-scraping-multiple-pages-with-scrapy.md
@@ -313,7 +313,7 @@ $ scrapy shell "https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID
 
 
 ~~~
->>> response.xpath("//h3[text()='Electorate Office ']/following-sibling::dl/dd[1]/text()").extract()
+>>> response.xpath("//h3[text()='Electorate Office ']/following-sibling::dl/dd[1]/a/text()").extract()
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
This updates the phone number example in the scrapy shell to include the
<a> tag in the xpath.

Extends #5 